### PR TITLE
Label party-battle resources for pruning

### DIFF
--- a/.github/scripts/add_party_battle_backend_version.sh
+++ b/.github/scripts/add_party_battle_backend_version.sh
@@ -16,6 +16,8 @@ SVC="party-battle-backend-v$(echo "${BACKEND_VERSION}" | tr '.' '-')"
 mkdir -p "${DIR}"
 
 cat > "${DIR}/kustomization.yaml" <<EOF
+commonLabels:
+  app.kubernetes.io/part-of: party-battle
 resources:
   - 01-service.yml
   - 02-deployment.yml

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -73,7 +73,7 @@ jobs:
           kubectl apply -k ${{ env.DEPLOY_PATH }}/kubernetes/metrics
           kubectl apply -k ${{ env.DEPLOY_PATH }}/kubernetes/jetski
           kubectl apply -k ${{ env.DEPLOY_PATH }}/kubernetes/homepage
-          kubectl apply -k ${{ env.DEPLOY_PATH }}/kubernetes/party-battle
+          kubectl apply -k ${{ env.DEPLOY_PATH }}/kubernetes/party-battle --prune -l app.kubernetes.io/part-of=party-battle
 
           echo "Cleaning up"
           rm -rf ${{ env.DEPLOY_PATH }}

--- a/kubernetes/party-battle/backend/catchall/kustomization.yaml
+++ b/kubernetes/party-battle/backend/catchall/kustomization.yaml
@@ -1,3 +1,5 @@
+commonLabels:
+  app.kubernetes.io/part-of: party-battle
 resources:
   - 01-service.yml
   - 02-deployment.yml

--- a/kubernetes/party-battle/backend/kustomization.yaml
+++ b/kubernetes/party-battle/backend/kustomization.yaml
@@ -1,3 +1,5 @@
+commonLabels:
+  app.kubernetes.io/part-of: party-battle
 resources:
   - catchall/
   - versions/v1.3.2/

--- a/kubernetes/party-battle/backend/versions/v1.3.2/kustomization.yaml
+++ b/kubernetes/party-battle/backend/versions/v1.3.2/kustomization.yaml
@@ -1,3 +1,5 @@
+commonLabels:
+  app.kubernetes.io/part-of: party-battle
 resources:
   - 01-service.yml
   - 02-deployment.yml

--- a/kubernetes/party-battle/backend/versions/v1.3.5/kustomization.yaml
+++ b/kubernetes/party-battle/backend/versions/v1.3.5/kustomization.yaml
@@ -1,3 +1,5 @@
+commonLabels:
+  app.kubernetes.io/part-of: party-battle
 resources:
   - 01-service.yml
   - 02-deployment.yml

--- a/kubernetes/party-battle/frontend/kustomization.yaml
+++ b/kubernetes/party-battle/frontend/kustomization.yaml
@@ -1,3 +1,5 @@
+commonLabels:
+  app.kubernetes.io/part-of: party-battle
 resources:
   - 01-service.yml
   - 02-deployment.yml

--- a/kubernetes/party-battle/kustomization.yaml
+++ b/kubernetes/party-battle/kustomization.yaml
@@ -1,3 +1,5 @@
+commonLabels:
+  app.kubernetes.io/part-of: party-battle
 resources:
   - frontend/
   - backend/


### PR DESCRIPTION
## Summary
- tag all party-battle kustomizations with `app.kubernetes.io/part-of=party-battle`
- enable `kubectl apply --prune` in deploy workflow
- ensure backend version workflow labels new kustomizations for pruning

## Testing
- `$(go env GOBIN)/kustomize build kubernetes/party-battle | head -n 20`


------
https://chatgpt.com/codex/tasks/task_b_68aae4ea25b8832e86e5e8aca3ccc33f